### PR TITLE
Test for exclusiveSelectionGroups

### DIFF
--- a/code/test/Templates.Test/BaseGenAndBuildTests.cs
+++ b/code/test/Templates.Test/BaseGenAndBuildTests.cs
@@ -80,12 +80,20 @@ namespace Microsoft.Templates.Test
 
         protected async Task<(string projectName, string projectPath)> GenerateAllPagesAndFeaturesAsync(string projectType, string framework, string platform, string language)
         {
+            // get first item from each exclusive selection group
+            var exclusiveSelectionGroups = GenContext.ToolBox.Repo.GetAll().Where(t =>
+                (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && t.GetIsGroupExclusiveSelection()).GroupBy(t => t.GetGroup(), (key, g) => g.First());
 
             Func<ITemplateInfo, bool> templateSelector = 
                     t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
                     && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                     && t.GetFrontEndFrameworkList().Contains(framework)
                     && t.GetPlatform() == platform
+                    && (!t.GetIsGroupExclusiveSelection() || (t.GetIsGroupExclusiveSelection() && exclusiveSelectionGroups.Contains(t)))
                     && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}All{ShortLanguageName(language)}";

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildCodeBehindProjectTests.cs
@@ -10,6 +10,8 @@ using Microsoft.TemplateEngine.Abstractions;
 
 using Xunit;
 using Microsoft.Templates.Fakes;
+using Microsoft.Templates.Core.Gen;
+using System.Linq;
 
 namespace Microsoft.Templates.Test
 {
@@ -67,11 +69,20 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "BuildAllPagesAndFeatures")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationAsync(string projectType, string framework, string platform, string language)
         {
+            // get first item from each exclusive selection group
+            var exclusiveSelectionGroups = GenContext.ToolBox.Repo.GetAll().Where(t =>
+                (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && t.GetIsGroupExclusiveSelection()).GroupBy(t => t.GetGroup(), (key, g) => g.First());
+
             Func<ITemplateInfo, bool> templateSelector =
                     t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
                     && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                     && t.GetFrontEndFrameworkList().Contains(framework)
                     && t.GetPlatform() == platform
+                    && (!t.GetIsGroupExclusiveSelection() || (t.GetIsGroupExclusiveSelection() && exclusiveSelectionGroups.Contains(t)))
                     && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}{ShortLanguageName(language)}";
@@ -103,11 +114,20 @@ namespace Microsoft.Templates.Test
 
         private async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string platform, string language)
         {
+            // get first item from each exclusive selection group
+            var exclusiveSelectionGroups = GenContext.ToolBox.Repo.GetAll().Where(t =>
+                (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && t.GetIsGroupExclusiveSelection()).GroupBy(t => t.GetGroup(), (key, g) => g.First());
+
             Func<ITemplateInfo, bool> templateSelector =
                     t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
                     && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                     && t.GetFrontEndFrameworkList().Contains(framework)
                     && t.GetPlatform() == platform
+                    && (!t.GetIsGroupExclusiveSelection() || (t.GetIsGroupExclusiveSelection() && exclusiveSelectionGroups.Contains(t)))
                     && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}AllRandom{ShortLanguageName(language)}";

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMBasicProjectTests.cs
@@ -10,6 +10,8 @@ using Microsoft.TemplateEngine.Abstractions;
 
 using Xunit;
 using Microsoft.Templates.Fakes;
+using Microsoft.Templates.Core.Gen;
+using System.Linq;
 
 namespace Microsoft.Templates.Test
 {
@@ -69,12 +71,21 @@ namespace Microsoft.Templates.Test
         public async Task BuildAllPagesAndFeaturesProjectNameValidationAsync(string projectType, string framework, string platform, string language)
         {
 
+            // get first item from each exclusive selection group
+            var exclusiveSelectionGroups = GenContext.ToolBox.Repo.GetAll().Where(t =>
+                (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && t.GetIsGroupExclusiveSelection()).GroupBy(t => t.GetGroup(), (key, g) => g.First());
+
             Func<ITemplateInfo, bool> templateSelector =
-                        t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
-                        && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
-                        && t.GetFrontEndFrameworkList().Contains(framework)
-                        && t.GetPlatform() == platform
-                        && !t.GetIsHidden();
+                    t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && (!t.GetIsGroupExclusiveSelection() || (t.GetIsGroupExclusiveSelection() && exclusiveSelectionGroups.Contains(t)))
+                    && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}{ShortLanguageName(language)}";
 
@@ -105,11 +116,20 @@ namespace Microsoft.Templates.Test
 
         private async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string platform, string language)
         {
+            // get first item from each exclusive selection group
+            var exclusiveSelectionGroups = GenContext.ToolBox.Repo.GetAll().Where(t =>
+                (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && t.GetIsGroupExclusiveSelection()).GroupBy(t => t.GetGroup(), (key, g) => g.First());
+
             Func<ITemplateInfo, bool> templateSelector =
                     t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
                     && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                     && t.GetFrontEndFrameworkList().Contains(framework)
                     && t.GetPlatform() == platform
+                    && (!t.GetIsGroupExclusiveSelection() || (t.GetIsGroupExclusiveSelection() && exclusiveSelectionGroups.Contains(t)))
                     && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}AllRandom{ShortLanguageName(language)}";

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildMVVMLightProjectTests.cs
@@ -10,6 +10,8 @@ using Microsoft.TemplateEngine.Abstractions;
 
 using Xunit;
 using Microsoft.Templates.Fakes;
+using Microsoft.Templates.Core.Gen;
+using System.Linq;
 
 namespace Microsoft.Templates.Test
 {
@@ -68,11 +70,20 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "BuildAllPagesAndFeatures")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationAsync(string projectType, string framework, string platform, string language)
         {
+            // get first item from each exclusive selection group
+            var exclusiveSelectionGroups = GenContext.ToolBox.Repo.GetAll().Where(t =>
+                (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && t.GetIsGroupExclusiveSelection()).GroupBy(t => t.GetGroup(), (key, g) => g.First());
+
             Func<ITemplateInfo, bool> templateSelector =
                     t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
                     && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                     && t.GetFrontEndFrameworkList().Contains(framework)
                     && t.GetPlatform() == platform
+                    && (!t.GetIsGroupExclusiveSelection() || (t.GetIsGroupExclusiveSelection() && exclusiveSelectionGroups.Contains(t)))
                     && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}{ShortLanguageName(language)}";
@@ -104,11 +115,20 @@ namespace Microsoft.Templates.Test
 
         private async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string platform, string language)
         {
+            // get first item from each exclusive selection group
+            var exclusiveSelectionGroups = GenContext.ToolBox.Repo.GetAll().Where(t =>
+                (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && t.GetIsGroupExclusiveSelection()).GroupBy(t => t.GetGroup(), (key, g) => g.First());
+
             Func<ITemplateInfo, bool> templateSelector =
                     t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
                     && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                     && t.GetFrontEndFrameworkList().Contains(framework)
                     && t.GetPlatform() == platform
+                    && (!t.GetIsGroupExclusiveSelection() || (t.GetIsGroupExclusiveSelection() && exclusiveSelectionGroups.Contains(t)))
                     && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}AllRandom{ShortLanguageName(language)}";

--- a/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
+++ b/code/test/Templates.Test/BuildTemplatesTests/BuildPrismProjectTests.cs
@@ -10,6 +10,8 @@ using Microsoft.TemplateEngine.Abstractions;
 
 using Xunit;
 using Microsoft.Templates.Fakes;
+using Microsoft.Templates.Core.Gen;
+using System.Linq;
 
 namespace Microsoft.Templates.Test
 {
@@ -69,11 +71,20 @@ namespace Microsoft.Templates.Test
         [Trait("Type", "BuildAllPagesAndFeatures")]
         public async Task BuildAllPagesAndFeaturesProjectNameValidationAsync(string projectType, string framework, string platform, string language)
         {
+            // get first item from each exclusive selection group
+            var exclusiveSelectionGroups = GenContext.ToolBox.Repo.GetAll().Where(t =>
+                (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && t.GetIsGroupExclusiveSelection()).GroupBy(t => t.GetGroup(), (key, g) => g.First());
+
             Func<ITemplateInfo, bool> templateSelector =
                     t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
                     && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                     && t.GetFrontEndFrameworkList().Contains(framework)
                     && t.GetPlatform() == platform
+                    && (!t.GetIsGroupExclusiveSelection() || (t.GetIsGroupExclusiveSelection() && exclusiveSelectionGroups.Contains(t)))
                     && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}{CharactersThatMayCauseProjectNameIssues()}{ShortLanguageName(language)}";
@@ -90,11 +101,20 @@ namespace Microsoft.Templates.Test
         [Trait("ExecutionSet", "BuildMinimum")]
         public async Task BuildAllPagesAndFeaturesRandomNamesAsync(string projectType, string framework, string platform, string language)
         {
+            // get first item from each exclusive selection group
+            var exclusiveSelectionGroups = GenContext.ToolBox.Repo.GetAll().Where(t =>
+                (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                    && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
+                    && t.GetFrontEndFrameworkList().Contains(framework)
+                    && t.GetPlatform() == platform
+                    && t.GetIsGroupExclusiveSelection()).GroupBy(t => t.GetGroup(), (key, g) => g.First());
+
             Func<ITemplateInfo, bool> templateSelector =
                     t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
                     && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                     && t.GetFrontEndFrameworkList().Contains(framework)
                     && t.GetPlatform() == platform
+                    && (!t.GetIsGroupExclusiveSelection() || (t.GetIsGroupExclusiveSelection() && exclusiveSelectionGroups.Contains(t)))
                     && !t.GetIsHidden();
 
             var projectName = $"{ShortProjectType(projectType)}AllRandom";

--- a/code/test/Templates.Test/CodeAnalysis/StyleCopGenerationTestsFixture.cs
+++ b/code/test/Templates.Test/CodeAnalysis/StyleCopGenerationTestsFixture.cs
@@ -67,7 +67,24 @@ namespace Microsoft.Templates.Test
 
                 foreach (var framework in targetFrameworks)
                 {
-                    result.Add(new object[] { projectType, framework, platform });
+                    var templateIds = GenContext.ToolBox.Repo.GetAll().Where(
+                        t => (t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
+                        && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains("all"))
+                        && t.GetFrontEndFrameworkList().Contains(framework)
+                        && t.GetPlatform() == platform
+                        && t.GetIsGroupExclusiveSelection() == true);
+
+                    if (templateIds == null || templateIds.Count() == 0)
+                    {
+                        result.Add(new object[] { projectType, framework, platform, string.Empty });
+                    }
+                    else
+                    {
+                        foreach (var templateId in templateIds)
+                        {
+                            result.Add(new object[] { projectType, framework, platform, templateId.Identity });
+                        }
+                    }
                 }
             }
 

--- a/code/test/Templates.Test/CodeAnalysis/StyleCopProjectGenerationTests.cs
+++ b/code/test/Templates.Test/CodeAnalysis/StyleCopProjectGenerationTests.cs
@@ -25,14 +25,16 @@ namespace Microsoft.Templates.Test
         [Theory]
         [MemberData(nameof(GetProjectTemplatesForStyleCop))]
         [Trait("Type", "CodeStyle")]
-        public async Task GenerateAllPagesAndFeaturesAndCheckWithStyleCopAsync(string projectType, string framework, string platform)
+        public async Task GenerateAllPagesAndFeaturesAndCheckWithStyleCopAsync(string projectType, string framework, string platform, string exclusiveSelectionTemplateId)
         {
             Func<ITemplateInfo, bool> templateSelector =
                 t => ((t.GetTemplateType() == TemplateType.Page || t.GetTemplateType() == TemplateType.Feature)
                 && (t.GetProjectTypeList().Contains(projectType) || t.GetProjectTypeList().Contains(All))
                 && t.GetFrontEndFrameworkList().Contains(framework)
                 && t.GetPlatform() == platform
-                && !t.GetIsHidden())
+                && !t.GetIsHidden()
+                && !t.GetIsGroupExclusiveSelection())
+                || t.Identity == exclusiveSelectionTemplateId
                 || (t.Name == "Feature.Testing.StyleCop");
 
             var projectName = $"{projectType}{framework}AllStyleCop";


### PR DESCRIPTION
Quick summary of changes
- Add a stylecop tests for all templates + each template in  exclusiveSelection groups.
- Use first item of exclusiveSelectionGroups for other tests that add all pages

